### PR TITLE
feat!: swap all kubectl refrences with uds zarf tools kubectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ This repository is used to create zarf packages of multiple add-ons for EKS.
 
 The main intention is to be used with our terraform module [terraform-aws-eks](https://github.com/defenseunicorns/terraform-aws-eks). These Zarf packages will consume resources staged in AWS automatically or with Zarf you can override the values using a values.yaml file, providing your own values with a VALUES_OVERRIDES Zarf variable for each package.
 
+# Utility Dependencies
+
+ - [Zarf](https://github.com/zarf-dev/zarf)
+ - [UDS-cli](https://github.com/defenseunicorns/uds-cli)
+ - [jq](https://stedolan.github.io/jq/)
+ - [aws-cli](https://aws.amazon.com/cli/)
+
 # Example of how to use the Zarf package with arbitrary overrides using zarf dev
 
 The example below will template the output with arbitrary overrides akin to a `helm template` command.

--- a/packages/aws-load-balancer-controller/zarf.yaml
+++ b/packages/aws-load-balancer-controller/zarf.yaml
@@ -43,7 +43,7 @@ components:
             darwin: bash
         before:
           # get the cluster name
-          - cmd: kubectl config current-context | awk -F'[:/]' '{print $NF}'
+          - cmd: uds zarf tools kubectl config current-context | awk -F'[:/]' '{print $NF}'
             setVariables:
               - name: CLUSTER_NAME
           - cmd: aws eks describe-cluster --name ${ZARF_VAR_CLUSTER_NAME} --query 'cluster.endpoint' --output text | cut -d . -f3

--- a/packages/aws-node-termination-handler/zarf.yaml
+++ b/packages/aws-node-termination-handler/zarf.yaml
@@ -47,7 +47,7 @@ components:
             darwin: bash
         before:
           # get the cluster name
-          - cmd: kubectl config current-context | awk -F'[:/]' '{print $NF}'
+          - cmd: uds zarf tools kubectl config current-context | awk -F'[:/]' '{print $NF}'
             setVariables:
               - name: CLUSTER_NAME
           - cmd: aws eks describe-cluster --name ${ZARF_VAR_CLUSTER_NAME} --query 'cluster.endpoint' --output text | cut -d . -f3

--- a/packages/cluster-autoscaler/zarf.yaml
+++ b/packages/cluster-autoscaler/zarf.yaml
@@ -47,7 +47,7 @@ components:
             darwin: bash
         before:
           # get the cluster name
-          - cmd: kubectl config current-context | awk -F'[:/]' '{print $NF}'
+          - cmd: uds zarf tools kubectl config current-context | awk -F'[:/]' '{print $NF}'
             setVariables:
               - name: CLUSTER_NAME
           - cmd: aws eks describe-cluster --name ${ZARF_VAR_CLUSTER_NAME} --query 'cluster.endpoint' --output text | cut -d . -f3

--- a/packages/external-secrets/zarf.yaml
+++ b/packages/external-secrets/zarf.yaml
@@ -39,7 +39,7 @@ components:
             darwin: bash
         before:
           # get the cluster name
-          - cmd: kubectl config current-context | awk -F'[:/]' '{print $NF}'
+          - cmd: uds zarf tools kubectl config current-context | awk -F'[:/]' '{print $NF}'
             setVariables:
               - name: CLUSTER_NAME
           - cmd: |

--- a/packages/storageclass/zarf.yaml
+++ b/packages/storageclass/zarf.yaml
@@ -42,7 +42,7 @@ components:
             darwin: bash
         before:
           # get the cluster name
-          - cmd: kubectl config current-context | awk -F'[:/]' '{print $NF}'
+          - cmd: uds zarf tools kubectl config current-context | awk -F'[:/]' '{print $NF}'
             setVariables:
               - name: CLUSTER_NAME
           - cmd: |


### PR DESCRIPTION
Because our opinionation is that these zarf packages will be consumed via a uds-bundle I believe it makes sense to use the uds-cli vendored `kubectl` binary. This limits the amount of utilities that have to be installed and helps establish how these packages are meant to be used.